### PR TITLE
Allow salvaging ships and drop broken hull items

### DIFF
--- a/src/main/java/com/talhanation/smallships/entities/AbstractCannonShip.java
+++ b/src/main/java/com/talhanation/smallships/entities/AbstractCannonShip.java
@@ -125,7 +125,7 @@ public abstract class AbstractCannonShip extends AbstractShipDamage{
     }
 
     public boolean canShoot(){
-        return hasGunPowder() && hasCannonBall();
+        return hasCannonBall();
     }
 
     public boolean hasGunPowder(){
@@ -277,13 +277,8 @@ public abstract class AbstractCannonShip extends AbstractShipDamage{
     public void handleItemsOnShoot() {
         Inventory inventory = this.getInventory();
 
-        int cannonball = 0;
-        int gunpowder = 0;
-
-        Item gunpowderItem = Items.GUNPOWDER;
         Item cannonballItem = ModItems.CANNONBALL.get();
 
-        this.shrinkItemInInv(inventory, gunpowderItem, 1);
         this.shrinkItemInInv(inventory, cannonballItem, 1);
     }
 

--- a/src/main/java/com/talhanation/smallships/entities/AbstractSailShip.java
+++ b/src/main/java/com/talhanation/smallships/entities/AbstractSailShip.java
@@ -61,6 +61,8 @@ public abstract class AbstractSailShip extends AbstractWaterVehicle {
     private static final DataParameter<Boolean> LEFT_PADDLE = EntityDataManager.defineId(AbstractSailShip.class, DataSerializers.BOOLEAN);
     private static final DataParameter<Boolean> RIGHT_PADDLE = EntityDataManager.defineId(AbstractSailShip.class, DataSerializers.BOOLEAN);
 
+    public static final String BROKEN_TAG = "SmallShipsBroken";
+
     public AbstractSailShip(EntityType<? extends AbstractWaterVehicle> type, World world) {
         super(type, world);
         this.maxUpStep = 0.2F;
@@ -685,6 +687,14 @@ public abstract class AbstractSailShip extends AbstractWaterVehicle {
             case DARK_OAK:
                 return Items.DARK_OAK_BOAT;
         }
+    }
+
+    protected ItemStack createShipItemStack(boolean broken) {
+        ItemStack stack = new ItemStack(this.getItemBoat());
+        if (broken) {
+            stack.getOrCreateTag().putBoolean(BROKEN_TAG, true);
+        }
+        return stack;
     }
 
     public enum Type {

--- a/src/main/java/com/talhanation/smallships/entities/AbstractShipDamage.java
+++ b/src/main/java/com/talhanation/smallships/entities/AbstractShipDamage.java
@@ -1,5 +1,6 @@
 package com.talhanation.smallships.entities;
 
+import com.talhanation.smallships.DamageSourceCannonball;
 import com.talhanation.smallships.DamageSourceShip;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
@@ -9,6 +10,7 @@ import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.entity.projectile.ArrowEntity;
 import net.minecraft.entity.projectile.ProjectileEntity;
 import net.minecraft.entity.projectile.TridentEntity;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
@@ -27,6 +29,7 @@ public abstract class AbstractShipDamage extends AbstractBannerUser {
     private static final DataParameter<Float> DAMAGE = EntityDataManager.defineId(AbstractShipDamage.class, DataSerializers.FLOAT);
     private static final DataParameter<Boolean> SUNKEN = EntityDataManager.defineId(AbstractShipDamage.class, DataSerializers.BOOLEAN);
     private int sunkenTimer = 0;
+    private boolean dropBrokenItemOnDestroy;
 
     public AbstractShipDamage(EntityType<? extends AbstractShipDamage> type, World world) {
         super(type, world);
@@ -80,6 +83,7 @@ public abstract class AbstractShipDamage extends AbstractBannerUser {
         super.addAdditionalSaveData(nbt);
         nbt.putFloat("Damage", getShipDamage());
         nbt.putBoolean("Sunken", getSunken());
+        nbt.putBoolean("DropBrokenItem", dropBrokenItemOnDestroy);
     }
 
     @Override
@@ -87,6 +91,7 @@ public abstract class AbstractShipDamage extends AbstractBannerUser {
         super.readAdditionalSaveData(nbt);
         setShipDamage(nbt.getFloat("Damage"));
         setSunken(nbt.getBoolean("Sunken"));
+        dropBrokenItemOnDestroy = nbt.getBoolean("DropBrokenItem");
     }
 
     ////////////////////////////////////GET////////////////////////////////////
@@ -124,8 +129,12 @@ public abstract class AbstractShipDamage extends AbstractBannerUser {
     }
 
     public void setShipDamage(float damage) {
-        if(getShipDamage() <= 100)
-        entityData.set(DAMAGE, damage);
+        if (getShipDamage() <= 100) {
+            entityData.set(DAMAGE, damage);
+        }
+        if (damage < 100F) {
+            setDropBrokenItemOnDestroy(false);
+        }
     }
 
     ////////////////////////////////////ON FUNCTIONS////////////////////////////////////
@@ -135,6 +144,8 @@ public abstract class AbstractShipDamage extends AbstractBannerUser {
         if (isInvulnerable() || level.isClientSide || !isAlive()) {
             return false;
         }
+
+        float previousDamage = this.getShipDamage();
 
         if (source.getDirectEntity() instanceof PlayerEntity){
             PlayerEntity player = (PlayerEntity) source.getDirectEntity();
@@ -168,12 +179,39 @@ public abstract class AbstractShipDamage extends AbstractBannerUser {
             this.setSunken(true);
         if (amount >= 2)
             damageShip(amount);
+        float newDamage = this.getShipDamage();
+        if (previousDamage < 100F && newDamage >= 100F) {
+            setDropBrokenItemOnDestroy(source == DamageSourceCannonball.DAMAGE_CANNONBALL);
+        }
         return false;
     }
 
     public abstract ResourceLocation getLootTable();
 
+    protected void setDropBrokenItemOnDestroy(boolean drop) {
+        this.dropBrokenItemOnDestroy = drop;
+    }
+
+    protected boolean shouldDropBrokenItemOnDestroy() {
+        return this.dropBrokenItemOnDestroy;
+    }
+
+    @Override
+    protected ItemStack createShipItemStack(boolean broken) {
+        if (broken) {
+            Item brokenHullItem = this.getBrokenHullItem();
+            return brokenHullItem == null ? ItemStack.EMPTY : new ItemStack(brokenHullItem);
+        }
+        return super.createShipItemStack(false);
+    }
+
+    protected abstract Item getBrokenHullItem();
+
     public void destroyShip(DamageSource source) {
+        if (!this.level.isClientSide && shouldDropBrokenItemOnDestroy()) {
+            this.spawnAtLocation(this.createShipItemStack(true));
+            setDropBrokenItemOnDestroy(false);
+        }
         super.destroyShip(source);
         kill();
     }

--- a/src/main/java/com/talhanation/smallships/entities/BriggEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/BriggEntity.java
@@ -9,6 +9,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.*;
 import net.minecraft.particles.ParticleTypes;
 import net.minecraft.util.ActionResultType;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.Hand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
@@ -130,12 +131,44 @@ public class BriggEntity extends AbstractCannonShip{
         return 6;
     }
 
+    @Override
+    public Item getItemBoat() {
+        switch (this.getWoodType()) {
+            case SPRUCE:
+                return ModItems.SPRUCE_BRIGG_ITEM.get();
+            case BIRCH:
+                return ModItems.BIRCH_BRIGG_ITEM.get();
+            case JUNGLE:
+                return ModItems.JUNGLE_BRIGG_ITEM.get();
+            case ACACIA:
+                return ModItems.ACACIA_BRIGG_ITEM.get();
+            case DARK_OAK:
+                return ModItems.DARK_OAK_BRIGG_ITEM.get();
+            case OAK:
+            default:
+                return ModItems.OAK_BRIGG_ITEM.get();
+        }
+    }
+
+    @Override
+    protected Item getBrokenHullItem() {
+        return ModItems.BROKEN_BRIGG_HULL.get();
+    }
+
     ////////////////////////////////////INTERACTIONS///////////////////////////////
 
     @Override
     public ActionResultType interact(PlayerEntity player, Hand hand) {
         ItemStack itemInHand = player.getItemInHand(hand);
         if (player.isSecondaryUseActive()) {
+            if (this.getPassengers().isEmpty()) {
+                if (!this.level.isClientSide) {
+                    setDropBrokenItemOnDestroy(false);
+                    this.spawnAtLocation(this.createShipItemStack(false));
+                    this.destroyShip(DamageSource.GENERIC);
+                }
+                return ActionResultType.sidedSuccess(this.level.isClientSide);
+            }
 
             if (this.isVehicle() && !(getControllingPassenger() instanceof PlayerEntity)) {
                 this.ejectPassengers();

--- a/src/main/java/com/talhanation/smallships/entities/CogEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/CogEntity.java
@@ -9,6 +9,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.*;
 import net.minecraft.particles.ParticleTypes;
 import net.minecraft.util.ActionResultType;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.Hand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
@@ -120,6 +121,30 @@ public class CogEntity extends AbstractCannonShip{
         }
     }
 
+    @Override
+    public Item getItemBoat() {
+        switch (this.getWoodType()) {
+            case SPRUCE:
+                return ModItems.SPRUCE_COG_ITEM.get();
+            case BIRCH:
+                return ModItems.BIRCH_COG_ITEM.get();
+            case JUNGLE:
+                return ModItems.JUNGLE_COG_ITEM.get();
+            case ACACIA:
+                return ModItems.ACACIA_COG_ITEM.get();
+            case DARK_OAK:
+                return ModItems.DARK_OAK_COG_ITEM.get();
+            case OAK:
+            default:
+                return ModItems.OAK_COG_ITEM.get();
+        }
+    }
+
+    @Override
+    protected Item getBrokenHullItem() {
+        return ModItems.BROKEN_COG_HULL.get();
+    }
+
     public int getMaxCannons(){//max cannons
         return 4;
     }
@@ -130,6 +155,14 @@ public class CogEntity extends AbstractCannonShip{
     public ActionResultType interact(PlayerEntity player, Hand hand) {
         ItemStack itemInHand = player.getItemInHand(hand);
         if (player.isSecondaryUseActive()) {
+            if (this.getPassengers().isEmpty()) {
+                if (!this.level.isClientSide) {
+                    setDropBrokenItemOnDestroy(false);
+                    this.spawnAtLocation(this.createShipItemStack(false));
+                    this.destroyShip(DamageSource.GENERIC);
+                }
+                return ActionResultType.sidedSuccess(this.level.isClientSide);
+            }
 
             if (this.isVehicle() && !(getControllingPassenger() instanceof PlayerEntity)) {
                 this.ejectPassengers();

--- a/src/main/java/com/talhanation/smallships/init/ModItems.java
+++ b/src/main/java/com/talhanation/smallships/init/ModItems.java
@@ -17,6 +17,8 @@ public class ModItems {
     public static final RegistryObject<Item> SAIL_ITEM = ITEMS.register("sail_item", () -> new Item((new Item.Properties().stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION))));
     public static final RegistryObject<Item> CANNON_ITEM = ITEMS.register("cannon_item", () -> new Item((new Item.Properties().stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION))));
     public static final RegistryObject<Item> CANNONBALL = ITEMS.register("cannonball_item", () -> new Item((new Item.Properties().stacksTo(16).tab(ItemGroup.TAB_TRANSPORTATION))));
+    public static final RegistryObject<Item> BROKEN_COG_HULL = ITEMS.register("broken_cog_hull", () -> new Item((new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));
+    public static final RegistryObject<Item> BROKEN_BRIGG_HULL = ITEMS.register("broken_brigg_hull", () -> new Item((new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));
 
     public static final RegistryObject<Item> OAK_COG_ITEM = ITEMS.register("oak_cog", () -> new CogItem(CogEntity.Type.OAK, (new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));
     public static final RegistryObject<Item> SPRUCE_COG_ITEM = ITEMS.register("spruce_cog", () -> new CogItem(CogEntity.Type.SPRUCE, (new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));

--- a/src/main/java/com/talhanation/smallships/items/BriggItem.java
+++ b/src/main/java/com/talhanation/smallships/items/BriggItem.java
@@ -1,6 +1,7 @@
 package com.talhanation.smallships.items;
 
 import com.talhanation.smallships.client.render.RenderItemBrigg;
+import com.talhanation.smallships.entities.AbstractSailShip;
 import com.talhanation.smallships.entities.AbstractWaterVehicle;
 import com.talhanation.smallships.entities.BriggEntity;
 import com.talhanation.smallships.init.ModEntityTypes;
@@ -44,6 +45,9 @@ public class BriggItem extends Item {
     @Override
     public ActionResult<ItemStack> use(World worldIn, PlayerEntity playerIn, Hand handIn) {
         ItemStack itemstack = playerIn.getItemInHand(handIn);
+        if (itemstack.hasTag() && itemstack.getTag().getBoolean(AbstractSailShip.BROKEN_TAG)) {
+            return ActionResult.fail(itemstack);
+        }
         RayTraceResult raytraceresult = getPlayerPOVHitResult(worldIn, playerIn, RayTraceContext.FluidMode.ANY);
         if (raytraceresult.getType() == RayTraceResult.Type.MISS) {
             return ActionResult.pass(itemstack);

--- a/src/main/java/com/talhanation/smallships/items/CogItem.java
+++ b/src/main/java/com/talhanation/smallships/items/CogItem.java
@@ -2,6 +2,7 @@ package com.talhanation.smallships.items;
 
 import com.talhanation.smallships.client.render.RenderItemCog;
 import com.talhanation.smallships.entities.CogEntity;
+import com.talhanation.smallships.entities.AbstractSailShip;
 import com.talhanation.smallships.entities.AbstractWaterVehicle;
 import com.talhanation.smallships.init.ModEntityTypes;
 import net.minecraft.entity.Entity;
@@ -44,6 +45,9 @@ public class CogItem extends Item {
     @Override
     public ActionResult<ItemStack> use(World worldIn, PlayerEntity playerIn, Hand handIn) {
         ItemStack itemstack = playerIn.getItemInHand(handIn);
+        if (itemstack.hasTag() && itemstack.getTag().getBoolean(AbstractSailShip.BROKEN_TAG)) {
+            return ActionResult.fail(itemstack);
+        }
         RayTraceResult raytraceresult = getPlayerPOVHitResult(worldIn, playerIn, RayTraceContext.FluidMode.ANY);
         if (raytraceresult.getType() == RayTraceResult.Type.MISS) {
             return ActionResult.pass(itemstack);

--- a/src/main/resources/assets/smallships/lang/de_de.json
+++ b/src/main/resources/assets/smallships/lang/de_de.json
@@ -7,6 +7,8 @@
   "item.smallships.oak_cog": "Eichenholzkogge",
   "item.smallships.dark_oak_cog": "Schwarzeichenholzkogge",
   "item.smallships.sail_item": "Segel",
+  "item.smallships.broken_cog_hull": "Zerbrochener Koggenrumpf",
+  "item.smallships.broken_brigg_hull": "Zerbrochener Brigg-Rumpf",
 
   "entity.smallships.galley": "Galeere",
   "item.smallships.acacia_galley": "Akazienholzgaleere",

--- a/src/main/resources/assets/smallships/lang/en_us.json
+++ b/src/main/resources/assets/smallships/lang/en_us.json
@@ -21,6 +21,8 @@
   "item.smallships.sail_item": "Sail",
   "item.smallships.cannon_item": "Ship Cannon",
   "item.smallships.cannonball_item": "Round Shot",
+  "item.smallships.broken_cog_hull": "Broken Cog Hull",
+  "item.smallships.broken_brigg_hull": "Broken Brigg Hull",
 
   "entity.smallships.galley": "Galley",
   "item.smallships.acacia_galley": "Acacia Galley",

--- a/src/main/resources/assets/smallships/lang/fr_fr.json
+++ b/src/main/resources/assets/smallships/lang/fr_fr.json
@@ -7,6 +7,8 @@
   "item.smallships.oak_cog": "Voilier en chêne",
   "item.smallships.dark_oak_cog": "Voilier en chêne noir",
   "item.smallships.sail_item": "Voile",
+  "item.smallships.broken_cog_hull": "Coque de voilier cassée",
+  "item.smallships.broken_brigg_hull": "Coque de brigg cassée",
 
   "entity.smallships.galley": "Galère",
   "item.smallships.acacia_galley": "Galère en acacia",

--- a/src/main/resources/assets/smallships/lang/pt_br.json
+++ b/src/main/resources/assets/smallships/lang/pt_br.json
@@ -7,6 +7,8 @@
   "item.smallships.oak_cog": "Coca de Carvalho",
   "item.smallships.dark_oak_cog": "Coca de Carvalho Escuro",
   "item.smallships.sail_item": "Vela",
+  "item.smallships.broken_cog_hull": "Casco de coca quebrado",
+  "item.smallships.broken_brigg_hull": "Casco de brigue quebrado",
 
   "entity.smallships.galley": "Galé",
   "item.smallships.acacia_galley": "Galé de Acácia",

--- a/src/main/resources/assets/smallships/lang/ru_ru.json
+++ b/src/main/resources/assets/smallships/lang/ru_ru.json
@@ -7,6 +7,8 @@
   "item.smallships.oak_cog": "Когг из дуба",
   "item.smallships.dark_oak_cog": "Когг из тёмного дуба",
   "item.smallships.sail_item": "Парус",
+  "item.smallships.broken_cog_hull": "Сломанный корпус когга",
+  "item.smallships.broken_brigg_hull": "Сломанный корпус брига",
 
   "entity.smallships.galley": "Галера",
   "item.smallships.acacia_galley": "Галера из акации",

--- a/src/main/resources/assets/smallships/lang/tr_tr.json
+++ b/src/main/resources/assets/smallships/lang/tr_tr.json
@@ -7,6 +7,8 @@
   "item.smallships.oak_cog": "Meşe Yelkenli Tekne",
   "item.smallships.dark_oak_cog": "Koyu Meşe Yelkenli Tekne",
   "item.smallships.sail_item": "Yelken",
+  "item.smallships.broken_cog_hull": "Kırık yelkenli gövdesi",
+  "item.smallships.broken_brigg_hull": "Kırık brigg gövdesi",
 
   "entity.smallships.galley": "Kadırga",
   "item.smallships.acacia_galley": "Akasya Kadırga",

--- a/src/main/resources/assets/smallships/models/item/broken_brigg_hull.json
+++ b/src/main/resources/assets/smallships/models/item/broken_brigg_hull.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "minecraft:item/rabbit_foot"
+  }
+}

--- a/src/main/resources/assets/smallships/models/item/broken_cog_hull.json
+++ b/src/main/resources/assets/smallships/models/item/broken_cog_hull.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "minecraft:item/rabbit_foot"
+  }
+}


### PR DESCRIPTION
## Summary
- allow cannon ships to fire using only cannonballs
- enable sneak-right-click salvaging that returns the ship item when the deck is empty
- add dedicated broken hull items with rabbit foot visuals and drop them when cannon fire sinks a ship

## Testing
- `./gradlew build` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_b_68cf32d7a734832e8d057aaed7a50972